### PR TITLE
Correct build-deps in apt instruction

### DIFF
--- a/BUILD_INSTRUCTIONS
+++ b/BUILD_INSTRUCTIONS
@@ -62,5 +62,5 @@ Solution1:
 Find the location of the library that could not be found and add its full path to CMakeLists.txt file in the "TARGET_LINK_LIBRARIES" line
 
 To build WITHOUT KDE support on Debian Jessie, do:
-apt-get install cmake build-essential libsecret-1-dev libgcrypt20-dev kdelibs5-dev phonon-backend-vlc
+apt-get install build-essential cmake libgcrypt20-dev libsecret-1-dev libphonon-dev phonon-backend-vlc
 


### PR DESCRIPTION
Please pull.

Sorry for the inconvenience, I was pulling way too much unneeded packages.
However, the overhead is still huge. I think it's a better idea to drop phonon and use vlc or mplayer in non-kde builds.

It's not high on my prio list, but I guess I'll dive into this soon and do another PR, if that's OK with you.