### PR TITLE
Update build-deps on Debian Jessie for a non KDE build

### DIFF
--- a/BUILD_INSTRUCTIONS
+++ b/BUILD_INSTRUCTIONS
@@ -62,4 +62,4 @@ Solution1:
 Find the location of the library that could not be found and add its full path to CMakeLists.txt file in the "TARGET_LINK_LIBRARIES" line
 
 Doing a non KDE build on Debian Jessie, you need to:
-apt-get install build-essential cmake libgcrypt20-dev libsecret-1-dev mplayer
+apt-get install build-essential cmake libgcrypt20-dev libsecret-1-dev mplayer qt4-dev


### PR DESCRIPTION
I always have qt4-dev installed, so I missed the dep