### PR TITLE
Fix build with -DKF5=true

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ if( KF5 )
 	find_package( KF5Notifications REQUIRED)
 	find_package( KF5CoreAddons )
 	find_package( KF5I18n NO_MODULE )
+	find_package( Qt5DBus REQUIRED )
 
 	message( STATUS "\n------------------------------------------------------------------------------------------" )
 	message( STATUS "kde support found,will build KStatusNotifierItem based tray icon application" )


### PR DESCRIPTION
This fixes build if `-DKF5=true` option is set which otherwise fail as described in https://github.com/mhogomchungu/qCheckGMail/issues/39#issuecomment-473687460 . Note that kwallet support still fails to build as mentioned later in the above comment.